### PR TITLE
Remove --ignore-scripts from publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
-name: main 
+name: main
 
 on:
   push:
-    branches: [ main ]
-
+    branches: [main]
 
 jobs:
   build:
@@ -24,7 +23,6 @@ jobs:
         env:
           CI: true
 
-
   publish:
     if: github.ref == 'refs/heads/main'
     needs: build
@@ -37,6 +35,6 @@ jobs:
       - name: Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm publish --ignore-scripts
+          npm publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mergeapi/merge-accounting-node",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "NodeJS client for merge_accounting_client",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description of the change

So `prepublishOnly` runs before `publish`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.

